### PR TITLE
Chore(fusdc-ocw): Read feedPolicy from Fusdc configuration endpoint

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -130,24 +130,6 @@ export const getChainFromEndpoint = (endpoint: string) => {
 }
 
 /**
- * Gets the FastUsdc FeedPolicy from FUSDC_CONFIG_ENDPOINT
- * @returns {?FeedPolicy} The FeedPolicy object or null if an error occurs
- */
-export const getFusdcFeedPolicy = async () => {
-  try {
-    const response = await globalThis.fetch(`${FUSDC_CONFIG_ENDPOINT}/feedPolicy`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch feed policy: ${response.statusText}`);
-    }
-    const feedPolicy: FeedPolicy = await response.json()
-    return feedPolicy;
-  } catch (error) {
-    logger.error(`Error fetching feed policy: ${error}`);
-    return null
-  }
-}
-
-/**
  * Gets the chain config from a name
  * @param chainName chain name
  * @returns the Chain config or null if the name is not found

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,5 @@
 import { config } from 'dotenv';
-import { AgoricAddress, ChainConfig } from '../types';
+import { AgoricAddress, ChainConfig, FeedPolicy } from '../types';
 import { logger } from '../utils/logger';
 import { PROD } from '../constants';
 
@@ -111,6 +111,11 @@ export const NOBLE_RPC_WS_URL = process.env.NOBLE_RPC_WS_URL || 'https://noble-r
 export const DB_URL = process.env.DB_URL
 
 /**
+ * Holds the Fusdc Configuration Endpoint
+ */
+export const FUSDC_CONFIG_ENDPOINT = 'https://fastusdc-configurations.agoric.net'
+
+/**
  * Gets the chain config from an endpoint
  * @param endpoint endpoint url
  * @returns the Chain config or null if the endpoint is not found
@@ -123,6 +128,26 @@ export const getChainFromEndpoint = (endpoint: string) => {
   }
   return null
 }
+
+/**
+ * Gets the FastUsdc FeedPolicy from FUSDC_CONFIG_ENDPOINT
+ * @returns {?FeedPolicy} The FeedPolicy object or null if an error occurs
+ */
+export const getFusdcFeedPolicy = async () => {
+  try {
+    const response = await globalThis.fetch(`${FUSDC_CONFIG_ENDPOINT}/feedPolicy`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch feed policy: ${response.statusText}`);
+    }
+    const feedPolicy: FeedPolicy = await response.json()
+    return feedPolicy;
+  } catch (error) {
+    logger.error(`Error fetching feed policy: ${error}`);
+    return null
+  }
+}
+
+console.log(getFusdcFeedPolicy())
 
 /**
  * Gets the chain config from a name

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -147,8 +147,6 @@ export const getFusdcFeedPolicy = async () => {
   }
 }
 
-console.log(getFusdcFeedPolicy())
-
 /**
  * Gets the chain config from a name
  * @param chainName chain name

--- a/src/lib/agoric.ts
+++ b/src/lib/agoric.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_AGORIC_RPC_INDEX, AGORIC_NETWORK, AGORIC_RPCS, AGORIC_WS_RPCS, ENV, MAX_OFFERS_TO_LOOP, QUERY_PARAMS_INTERVAL, RPC_RECONNECT_DELAY, WATCHER_WALLET_ADDRESS, nextActiveAgoricRPC, getFusdcFeedPolicy } from "../config/config";
+import { ACTIVE_AGORIC_RPC_INDEX, AGORIC_NETWORK, AGORIC_RPCS, AGORIC_WS_RPCS, ENV, MAX_OFFERS_TO_LOOP, QUERY_PARAMS_INTERVAL, RPC_RECONNECT_DELAY, WATCHER_WALLET_ADDRESS, nextActiveAgoricRPC, FUSDC_CONFIG_ENDPOINT } from "../config/config";
 import { logger } from "../utils/logger";
 import WebSocket from 'ws';
 import { execSync } from 'child_process';
@@ -567,3 +567,21 @@ export async function queryWorkerForNFA(address: NobleAddress) {
         return null
     }
 }
+
+/**
+ * Gets the FastUsdc FeedPolicy from FUSDC_CONFIG_ENDPOINT
+ * @returns {?FeedPolicy} The FeedPolicy object or null if an error occurs
+ */
+export async function getFusdcFeedPolicy() {
+    try {
+      const response = await axios.get(`${FUSDC_CONFIG_ENDPOINT}/feedPolicy`);
+      if (!response.data || response.status != 200) {
+        throw new Error(`Failed to fetch feed policy: ${response.statusText}`);
+      }
+      const feedPolicy: FeedPolicy = await response.data
+      return feedPolicy;
+    } catch (error) {
+      logger.error(`Error fetching feed policy: ${error}`);
+      return null
+    }
+  }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,8 @@ export type VStorage = {
   nobleDomainId: number;
 };
 
+export type FeedPolicy = VStorage
+
 export interface CctpTxSubmission {
   aux: {
     forwardingChannel: IBCChannelID;


### PR DESCRIPTION

### Description:
**Closes**:
https://github.com/SimplyStaking/agoric-ocw/issues/12

This PR reads `feedPolicy` from Agoric managed endpoint for Fusdc (instead of on-chain vstorage).

**Note:** Incase of any error from API, it reads from `vstorage` as a fallback.